### PR TITLE
Argparser bug fix for small_subset arg

### DIFF
--- a/sp2023/hw6/classification.py
+++ b/sp2023/hw6/classification.py
@@ -244,7 +244,7 @@ def pre_process(model_name, batch_size, device, small_subset=False):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument("--experiment", type=str, default=None)
-    parser.add_argument("--small_subset", type=bool, default=False)
+    parser.add_argument("--small_subset", type=str, default=False)
     parser.add_argument("--num_epochs", type=int, default=1)
     parser.add_argument("--lr", type=float, default=5e-5)
     parser.add_argument("--batch_size", type=int, default=32)
@@ -254,11 +254,18 @@ if __name__ == "__main__":
     args = parser.parse_args()
     print(f"Specified arguments: {args}")
 
+    # Handling argparse for small_subset param
+    small_subset = str(args.small_subset).upper()
+    if small_subset == 'TRUE' or small_subset == "1":
+        small_subset = True
+    else:
+        small_subset = False
+
     # load the data and models
     pretrained_model, train_dataloader, validation_dataloader, test_dataloader = pre_process(args.model,
                                                                                              args.batch_size,
                                                                                              args.device,
-                                                                                             args.small_subset)
+                                                                                             small_subset)
 
     print(" >>>>>>>>  Starting training ... ")
     train(...)


### PR DESCRIPTION
Current behavior:
Whatever value is passed to "small_subset", argparser parses it as True. Only when there is no "small_subset" param, it is parsed as False.

So it currently fails for testcases like:
--small_subset False
--small_subset false
--small_subset 0

So I have changed the argparser type to str with acceptable values in ['true', 'false', 0, 1] (case-insensitive). I have handled the above testcases and it is now working as expected for the following testcases:
--small_subset False
--small_subset false
--small_subset 0
--small_subset True
--small_subset true
--small_subset 1
